### PR TITLE
Fix directives processing in a fragment definition

### DIFF
--- a/luagraphqlparser/lib.c
+++ b/luagraphqlparser/lib.c
@@ -668,7 +668,7 @@ end_visit_fragment_definition(const struct GraphQLAstFragmentDefinition *def, vo
 
 		lua_pushliteral(L, "directives");
 		lua_insert(L, -2);
-		lua_settable(L, -3);
+		lua_settable(L, -4);
 	}
 
 	lua_pushliteral(L, "typeCondition");

--- a/test/directives_test.lua
+++ b/test/directives_test.lua
@@ -45,13 +45,13 @@ function g.test_with_fragment()
         definitions = {
             {
                 typeCondition = {
-                    directives = {
-                        {name = {kind = 'name', value = 'foo'}, kind = 'directive'},
-                    },
                     name = {
                         kind = 'name', value = 'Y',
                     },
                     kind = 'namedType',
+                },
+                directives = {
+                    {name = {kind = 'name', value = 'foo'}, kind = 'directive'},
                 },
                 selectionSet = {
                     selections = {


### PR DESCRIPTION
The problem is that we attach the 'directives' node to a wrong AST tree
node. Now it is in the fragment definition node (as should).

Overlooked it, my bad.

Follows up #2