### PR TITLE
cmake: fail early if no module.h found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" ${CMAKE_MODULE_PATH})
 
 # Find Tarantool and Lua dependencies
-set(TARANTOOL_FIND_REQUIRED ON)
+set(Tarantool_FIND_REQUIRED ON)
 find_package(Tarantool)
 include_directories(${TARANTOOL_INCLUDE_DIRS})
 


### PR DESCRIPTION
Commit 58d39d7ef712c5c664cd8f890ad46cb1cf32d47d ('cmake: fix warning')
causes a little regression: if there is no tarantool/module.h header, we
should fail at the cmake stage. After the fix of the warning we'll fail
only at the building stage (when `make` is called). Here I return the
old behaviour (fail on the `cmake` stage) back.

See https://github.com/tarantool/tuple-keydef/pull/20