### PR TITLE
rockspec: use git+https:// for git repository URL

### DIFF
--- a/luagraphqlparser-0.1.0-1.rockspec
+++ b/luagraphqlparser-0.1.0-1.rockspec
@@ -2,7 +2,7 @@ package = 'luagraphqlparser'
 version = '0.1.0-1'
 
 source  = {
-    url    = 'git://github.com/tarantool/luagraphqlparser.git';
+    url    = 'git+https://github.com/tarantool/luagraphqlparser.git';
     tag = '0.1.0';
 }
 

--- a/luagraphqlparser-0.2.0-1.rockspec
+++ b/luagraphqlparser-0.2.0-1.rockspec
@@ -2,7 +2,7 @@ package = 'luagraphqlparser'
 version = '0.2.0-1'
 
 source  = {
-    url    = 'git://github.com/tarantool/luagraphqlparser.git';
+    url    = 'git+https://github.com/tarantool/luagraphqlparser.git';
     tag = '0.2.0';
 }
 

--- a/luagraphqlparser-scm-1.rockspec
+++ b/luagraphqlparser-scm-1.rockspec
@@ -2,7 +2,7 @@ package = 'luagraphqlparser'
 version = 'scm-1'
 
 source  = {
-    url    = 'git://github.com/tarantool/luagraphqlparser.git';
+    url    = 'git+https://github.com/tarantool/luagraphqlparser.git';
     branch = 'master';
 }
 


### PR DESCRIPTION
GitHub is going to disable unencrypted Git protocol, so `git://` URLs
will stop working soon (see [1]).

[1]: https://github.blog/2021-09-01-improving-git-protocol-security-github/

Part of https://github.com/tarantool/tarantool/issues/6587